### PR TITLE
Array.isArray to $.isArray for browser compatibility

### DIFF
--- a/jquery.event.gevent.js
+++ b/jquery.event.gevent.js
@@ -72,7 +72,7 @@
   
       if ( arg_count > 1 ) {
         data      = arg_list.shift();
-        data_list = Array.isArray( data ) ? data : [ data ];
+        data_list = $.isArray( data ) ? data : [ data ];
       }
       else {
         data_list = [];


### PR DESCRIPTION
I prefer this way of checking for arrays because i had some problems on internet explorer 9, in this way should always work
